### PR TITLE
added wrapping in description column for reports

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -168,6 +168,9 @@
           &:last-child {
             padding-right: 1em;
           }
+          &.description {
+            white-space: normal;
+          }
           .project {
             position: relative;
             overflow: hidden;


### PR DESCRIPTION
This enabled wrapping on the description column to ensure the layout does not break if long content is uses (e.g. long comments)