### PR TITLE
Make Issue autocompletion less auto

### DIFF
--- a/app/assets/javascripts/forms.coffee
+++ b/app/assets/javascripts/forms.coffee
@@ -14,13 +14,13 @@ initIssueAutoCompletion = ->
       $(event.target).next().val('')
     select: (event, ui) ->
       event.preventDefault()
-      $issueField.trigger('change')
-      $projectField.val(ui.item.project_id).trigger('changefromissue') if $projectField.val() isnt ui.item.project_id
-    focus: (event, ui) ->
-      event.preventDefault()
       $issueField
       .val(ui.item.label)
       .next().val(ui.item.issue_id)
+      .trigger('change')
+      $projectField.val(ui.item.project_id).trigger('changefromissue') if $projectField.val() isnt ui.item.project_id
+    focus: (event, ui) ->
+      event.preventDefault()
 
 updateActivityField = ($activityField, $projectField) ->
   $selected_activity = $activityField.find("option:selected")


### PR DESCRIPTION
This fixes a common complaint, that when creating a booking, the issue autocompleter will overwrite the form field with whatever match comes up first in the search.

The simple solution is to carry over the autocompleter result in the select event, not just by focus.