### PR TITLE
Fix default_activity storage

### DIFF
--- a/lib/hourglass/redmine_patches/user_preference_patch.rb
+++ b/lib/hourglass/redmine_patches/user_preference_patch.rb
@@ -1,7 +1,13 @@
 module Hourglass
   module RedminePatches
     module UserPreferencePatch
+
       extend ActiveSupport::Concern
+
+      included do
+        # Redmine >= 3.4 introduces "safe_attributes"
+        self.try :safe_attributes, 'default_activity'
+      end
 
       def default_activity
         self[:default_activity]


### PR DESCRIPTION
The default_activity setting wan't correctly stored in the current setup, due to the mechanisms User Preferences are processed.
Surprisingly, once that's done correctly, the associated feature suddenly starts working.