### PR TITLE
Check for existence of icon-link before setting stuff on it

### DIFF
--- a/app/assets/javascripts/forms.coffee
+++ b/app/assets/javascripts/forms.coffee
@@ -62,8 +62,9 @@ updateDurationField = ($startField, $stopField) ->
 
 updateLink = ($field) ->
   $link = $field.closest('.form-field').find('label + a')
-  $link.toggleClass 'hidden', $field.val() is ''
-  $link.attr('href', $link.attr('href').replace(/\/([^/]*)$/, "/#{$field.val()}"))
+  if $link.length
+    $link.toggleClass 'hidden', $field.val() is ''
+    $link.attr('href', $link.attr('href').replace(/\/([^/]*)$/, "/#{$field.val()}"))
 
 formFieldChanged = (event) ->
   $target = $(event.target)


### PR DESCRIPTION
The form_fields for Issue and Project have a little icon linking to the Item, but only in the Time Tracker view.

In the Booking or Editing view, this icon is intentionally not present, which led to a Javascript error on the browser console.