### PR TITLE
Don't round time bookings in chart view

### DIFF
--- a/app/helpers/hourglass/chart_helper.rb
+++ b/app/helpers/hourglass/chart_helper.rb
@@ -37,7 +37,13 @@ module Hourglass
       query.total_by_group_for(:hours).transform_values do |totals_by_column|
         totals_by_column = {default: totals_by_column} unless query.main_query.group_by_statement
         totals_by_column.transform_keys! { |_| :default } if query.main_query.group_by == 'date'
-        Hash[totals_by_column.map { |column, total| [column, time_booking_total(total)] }]
+        Hash[totals_by_column.map { |column, total| [column, unrounded_total(total)] }]
+      end
+    end
+
+    def unrounded_total(total)
+      total.reduce(0.0) do |sum, total_by_project|
+        sum + total_by_project.sum.to_f.round(2)
       end
     end
 

--- a/app/helpers/hourglass/chart_helper.rb
+++ b/app/helpers/hourglass/chart_helper.rb
@@ -43,7 +43,7 @@ module Hourglass
 
     def unrounded_total(total)
       total.reduce(0.0) do |sum, total_by_project|
-        sum + total_by_project.sum.to_f.round(2)
+        sum + total_by_project[1].to_f.round(2)
       end
     end
 


### PR DESCRIPTION
There have been complaints about inconsistency between chart view and the summed hours value.
The long-term rounding algorithm will possibly round the sum between days, while the chart view rounds each day individually. This leads to a discrepancy.
The only and simplest fix i see is to disable rounding for the chart view, which will then show the real value, close to the computed rounded sum.