### PR TITLE
Consider global ActiveRecord config of database timezone when constructing queries

### DIFF
--- a/app/models/concerns/hourglass/query_base.rb
+++ b/app/models/concerns/hourglass/query_base.rb
@@ -36,6 +36,18 @@ module Hourglass::QueryBase
         QueryColumn.new name, options
       end
     end
+
+    def sql_timezoned_date(column_name)
+      tz = Rails.configuration.active_record.default_timezone
+      arg = case tz
+        when :local
+          'utc'
+        when :utc
+          'localtime'
+        else raise "Invalid Rails.config.active_record.default_timezone=#{tz}"
+      end
+      "DATE(#{column_name}, '#{arg}')"
+    end
   end
 
   def initialize(attributes = nil)

--- a/app/models/hourglass/time_booking_query.rb
+++ b/app/models/hourglass/time_booking_query.rb
@@ -3,7 +3,7 @@ module Hourglass
     include QueryBase
 
     set_available_columns(
-        date: {sortable: "#{queried_class.table_name}.start", groupable: "DATE(#{queried_class.table_name}.start)"},
+        date: {sortable: "#{queried_class.table_name}.start", groupable: sql_timezoned_date("#{queried_class.table_name}.start")},
         start: {},
         stop: {},
         hours: {totalable: true},

--- a/app/models/hourglass/time_log_query.rb
+++ b/app/models/hourglass/time_log_query.rb
@@ -1,13 +1,4 @@
-def sql_timezone
-  tz = Rails.configuration.active_record.default_timezone
-  case tz
-    when :local
-      'utc'
-    when :utc
-      'localtime'
-    else raise "Invalid Rails.config.active_record.default_timezone=#{tz}"
-  end
-end
+
 
 module Hourglass
   class TimeLogQuery < Query
@@ -16,7 +7,7 @@ module Hourglass
     set_available_columns(
         comments: {},
         user: {sortable: lambda { User.fields_for_order_statement }, groupable: true},
-        date: {sortable: "#{queried_class.table_name}.start", groupable: "DATE(#{queried_class.table_name}.start, '#{sql_timezone}')"},
+        date: {sortable: "#{queried_class.table_name}.start", groupable: sql_timezoned_date("#{queried_class.table_name}.start")},
         start: {},
         stop: {},
         hours: {totalable: true},

--- a/app/models/hourglass/time_log_query.rb
+++ b/app/models/hourglass/time_log_query.rb
@@ -1,3 +1,14 @@
+def sql_timezone
+  tz = Rails.configuration.active_record.default_timezone
+  case tz
+    when :local
+      'utc'
+    when :utc
+      'localtime'
+    else raise "Invalid Rails.config.active_record.default_timezone=#{tz}"
+  end
+end
+
 module Hourglass
   class TimeLogQuery < Query
     include QueryBase
@@ -5,7 +16,7 @@ module Hourglass
     set_available_columns(
         comments: {},
         user: {sortable: lambda { User.fields_for_order_statement }, groupable: true},
-        date: {sortable: "#{queried_class.table_name}.start", groupable: "DATE(#{queried_class.table_name}.start)"},
+        date: {sortable: "#{queried_class.table_name}.start", groupable: "DATE(#{queried_class.table_name}.start, '#{sql_timezone}')"},
         start: {},
         stop: {},
         hours: {totalable: true},

--- a/app/models/hourglass/time_tracker_query.rb
+++ b/app/models/hourglass/time_tracker_query.rb
@@ -5,7 +5,7 @@ module Hourglass
     set_available_columns(
         comments: {},
         user: {sortable: lambda { User.fields_for_order_statement }},
-        date: {sortable: "#{queried_class.table_name}.start", groupable: "DATE(#{queried_class.table_name}.start)"},
+        date: {sortable: "#{queried_class.table_name}.start", groupable: sql_timezoned_date("#{queried_class.table_name}.start")},
         start: {},
         hours: {},
         project: {sortable: "#{Project.table_name}.name", groupable: "#{Project.table_name}.id"},


### PR DESCRIPTION
If the `Rails.configuration.active_record.default_timezone` is set to `:local`, the SQL database will internally store dates in the server local timezone, not in UTC.
Model classes like TimeLog know this and will convert it back to UTC for internal handling. This creates an inconsistency and can lead to 500-type error messages when the TimeLogQuery doesn't instruct the SQL DB to do the same, because the same log might be associated with different days in different code paths.

I'm open to suggestions on where to place the `sql_timezone` function.