### PR TITLE
Filter by all target versions, not just system-wide shared ones

### DIFF
--- a/app/models/concerns/hourglass/query_base.rb
+++ b/app/models/concerns/hourglass/query_base.rb
@@ -194,7 +194,7 @@ module Hourglass::QueryBase
     versions = if project
                  project.shared_versions.to_a
                else
-                 Version.visible.where(sharing: 'system').to_a
+                 Version.visible.to_a
                end
     values = versions.uniq.sort.collect { |s| ["#{s.project.name} - #{s.name}", s.id.to_s] }
     add_available_filter 'fixed_version_id', type: :list_optional, values: values


### PR DESCRIPTION
There was a complaint that filtering queries by release version is limited to those versions with a system-wide scope.
The simplest answer is to allow filtering for all versions.
Depending on the usage of release versions, this might lead to a lot of irrelevant options. But i can't think of a better way, since the query mask itself doesn't have context about the search that could narrow the possible options.