### PR TITLE
Bug fixes for JavaScript in Redmine 4.1

### DIFF
--- a/app/assets/javascripts/forms.coffee
+++ b/app/assets/javascripts/forms.coffee
@@ -100,8 +100,8 @@ projectFieldChanged = (event) ->
   $projectField = $(@)
   $form = $projectField.closest('form')
   $issueTextField = $form.find('.js-issue-autocompletion')
-  $activityField = $form.find('[name*=v\\[activity_id\\]]')
-  $userField = $form.find('[name*=v\\[user_id\\]]')
+  $activityField = $form.find("[name*='[activity_id]']")
+  $userField = $form.find("[name*='[user_id]']")
 
   round = $projectField.find(':selected').data('round-default')
   $form.find('[type=checkbox][name*=round]').prop('checked', round) unless round is null

--- a/app/assets/javascripts/lists.coffee
+++ b/app/assets/javascripts/lists.coffee
@@ -54,6 +54,10 @@ checkForMultiForm = ($row, $formRow)->
     $visibleForms.find('.js-not-in-multi').prop('disabled', false)
 
 showInlineForm = (event, response) ->
+  responseText = response
+  if !responseText?
+    [_data, _status, xhr] = event.detail
+    responseText = xhr.responseText
   $row = $(@).closest 'tr'
   $row.addClass('hidden')
   $formRow = $row.clone().removeClass('hidden')
@@ -64,20 +68,21 @@ showInlineForm = (event, response) ->
   .removeClass 'hascontextmenu context-menu-selection'
   .empty()
   .append $('<td/>', class: 'hide-when-print')
-  .append $('<td/>', colspan: tdCount).append response
+  .append $('<td/>', colspan: tdCount).append responseText
   .insertAfter $row
   $formRow.find('.js-validate-limit').each addStartStopLimitMoments
   $durationField = $formRow.find('.js-duration')
   $durationField.val hourglass.Utils.formatDuration parseFloat($durationField.val()), 'hours' if $durationField
   checkForMultiForm $row, $formRow
 
-showInlineFormMulti = (event, response) ->
-  $(response).each ->
+showInlineFormMulti = (event) ->
+  [_data, _status, xhr] = event.detail
+  $(xhr.response).each ->
     showInlineForm.call $("##{$(@).data('id-for-bulk-edit')} .js-show-inline-form").get(), event, @
   window.contextMenuHide()
 
-showInlineFormCreate = (event, response) ->
-  showInlineForm.call $('.js-create-form-anchor').get(), event, response
+showInlineFormCreate = (event) ->
+  showInlineForm.call $('.js-create-form-anchor').get(), event
 
 hideInlineForm = (event) ->
   event.preventDefault()


### PR DESCRIPTION
* fixed a bug that prevented to edit time bookings (single and bulk)
* fixed a validation error at the activity field