### PR TITLE
Fixed time booking continue function

### DIFF
--- a/app/controllers/hourglass/time_trackers_controller.rb
+++ b/app/controllers/hourglass/time_trackers_controller.rb
@@ -11,7 +11,7 @@ module Hourglass
     end
 
     def start
-      time_tracker = authorize Hourglass::TimeTracker.new params[:time_tracker] ? time_tracker_params.except(:start) : {}
+      time_tracker = authorize Hourglass::TimeTracker.new time_tracker_params.present? ? time_tracker_params.except(:start) : {}
       if time_tracker.save
         respond_with_success time_tracker
       else

--- a/app/views/hourglass_ui/time_bookings/_list_entry_actions.slim
+++ b/app/views/hourglass_ui/time_bookings/_list_entry_actions.slim
@@ -4,10 +4,8 @@
   = render partial: 'hooks/time_tracker/start_dialog_content', locals: {time_tracker: time_tracker}
   - @once = (not nil)
 
-- booking_params = {:params=>{:time_tracker=>{:issue_id=>time_booking.issue&.id,
-    :activity_id => time_booking.activity&.id,
-    :comments => time_booking.comments}}}
-= link_to '', start_hourglass_time_trackers_path, class: 'icon-hourglass-continue js-hourglass-remote js-start-tracker', title: t(:button_continue), remote: true, method: 'post', data: booking_params
+- booking_params = {:time_tracker=>{:issue_id=>time_booking.issue&.id, :project_id => time_booking.project&.id, :activity_id => time_booking.activity&.id, :comments => time_booking.comments}}
+= link_to '', start_hourglass_time_trackers_path(booking_params), class: 'icon-hourglass-continue js-hourglass-remote js-start-tracker', title: t('hourglass.ui.time_bookings.button_continue'), remote: true, method: 'post'
 
 - if policy(time_booking).change?
   = link_to '', hourglass_ui_edit_time_bookings_path(time_booking), class: 'icon-edit js-show-inline-form', title: t(:button_edit), remote: true, data: {type: 'html'}

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -178,6 +178,7 @@ de:
       time_bookings:
         title: Zeitbuchungen
         button_create: Neue Zeitbuchung
+        button_continue: Fortsetzen
         no_data: Keine Zeitbuchungen vorhanden
         heading_report: Report
         label_print: Drucken

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -173,6 +173,7 @@ en:
       time_bookings:
         title: Time bookings
         button_create: New time booking
+        button_continue: Continue
         no_data: No time bookings available
         heading_report: Report
         label_print: Print

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -159,6 +159,7 @@ pt-BR:
       time_bookings:
         title: Reservas de tempo
         button_create: Nova reserva de tempo
+        button_continue: Continuar
         no_data: Nenhuma reserva de tempo disponível
         heading_report: Relatório
         label_print: Imprimir

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -159,6 +159,7 @@ ru:
       time_bookings:
         title: Регистрация затраченного времени
         button_create: Новая регистрация времени
+        button_continue: Продолжить
         no_data: Нет записей регистрации времени
         heading_report: Отчет
         label_print: Печать

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - redmine-data:/usr/src/redmine/files
       - .:/usr/src/redmine/plugins/redmine_hourglass
     environment:
+      RAILS_ENV: development
       REDMINE_DB_MYSQL: db
       REDMINE_DB_PASSWORD: example
       REDMINE_SECRET_KEY_BASE: supersecretkey


### PR DESCRIPTION
* fixed the time booking continue function, now the issue, project, activity and comment field will be prefilled when the tracker is started
* set the RAILS_ENV in docker-compose.yml to development 